### PR TITLE
Ignoring too many parameters warning for worker method

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -34,6 +34,11 @@ Metrics/MethodLength:
 Metrics/BlockLength:
   Enabled: false
 
+Metrics/ParameterLists:
+  Only:
+      - '/app/workers/invitation_worker.rb'
+  Enabled: false
+
 Naming/VariableNumber:
   EnforcedStyle: snake_case
 


### PR DESCRIPTION
I could alternatively put all the fields I'm sending into an array and then grab all the things out of the array, but that seems dirtyer than this, comment below