### PR TITLE
Disable HABTM checking

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -55,6 +55,9 @@ Style/StringLiterals:
 Style/NumericLiterals:
   Enabled: false
 
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
 Rails/SkipsModelValidations:
   Blacklist:
     - decrement!


### PR DESCRIPTION
Disables ```Prefer `has_many :through` to `has_and_belongs_to_many``` checks.