### PR TITLE
use implict style for rescueing errors

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -56,6 +56,9 @@ Style/StringLiterals:
 Style/NumericLiterals:
   Enabled: false
 
+Style/RescueStandardError:
+  EnforcedStyle: implicit
+
 Rails/HasAndBelongsToMany:
   Enabled: false
 


### PR DESCRIPTION
`rescue` will rescue `StandardError` by default so we can use the implicit style instead of having to specify the class each time