### PR TITLE
Revert "use implict style for rescueing errors"

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -56,9 +56,6 @@ Style/StringLiterals:
 Style/NumericLiterals:
   Enabled: false
 
-Style/RescueStandardError:
-  EnforcedStyle: implicit
-
 Rails/HasAndBelongsToMany:
   Enabled: false
 


### PR DESCRIPTION
This reverts commit 16ba033d1b01570ce4b247a09b0f77d56a1f576f.