### PR TITLE
Rjspotter/upgrade 55 to 68

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -59,6 +59,9 @@ Style/NumericLiterals:
 Rails/HasAndBelongsToMany:
   Enabled: false
 
+Rails/ReflectionClassName:
+  Enabled: false
+
 Rails/SkipsModelValidations:
   Blacklist:
     - decrement!

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -20,7 +20,7 @@ Layout/AlignParameters:
 Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
 Metrics/AbcSize:

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -17,7 +17,7 @@ Layout/MultilineMethodCallIndentation:
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
 Layout/IndentHash:
@@ -48,7 +48,7 @@ Style/FrozenStringLiteralComment:
   EnforcedStyle: never
 
 Style/HashSyntax:
-  EnforcedStyle: no_mixed_keys
+  EnforcedStyle: hash_rockets
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes


### PR DESCRIPTION
Upgrades to the latest rubocop syntax and rules (adding hashrockets)